### PR TITLE
Fix typo in doc (EBD instead of EDB)

### DIFF
--- a/R/auk-set-ebd-path.r
+++ b/R/auk-set-ebd-path.r
@@ -10,7 +10,7 @@
 #'
 #' @param path character; directory where the EBD text files are stored, e.g. 
 #'   `"/home/matt/ebd"`.
-#' @param overwrite logical; should the existing `EDB_PATH` be overwritten if it
+#' @param overwrite logical; should the existing `EBD_PATH` be overwritten if it
 #'   has already been set in .Renviron.
 #'
 #' @return Edits .Renviron, then returns the AWK path invisibly.


### PR DESCRIPTION
A simple typo I noticed. Hope that is correct.