### PR TITLE
Changes for readr 2.0.0

### DIFF
--- a/R/get-ebird-taxonomy.r
+++ b/R/get-ebird-taxonomy.r
@@ -45,7 +45,7 @@ get_ebird_taxonomy <- function(version, locale) {
   httr::stop_for_status(response)
   # read to data frame
   tax <- readBin(response$content, "character")
-  tax <- suppressWarnings(readr::read_csv(tax))
+  tax <- suppressWarnings(readr::read_csv(I(tax), col_types = list(), lazy = FALSE))
   names(tax) <- tolower(names(tax))
   # tidy up
   keep_names <- c("scientific_name", "common_name", "species_code", 


### PR DESCRIPTION
In previous version of readr the reading functions took literal data as any
filename with a newline in it or vectors of length > 1. In readr 2.0.0 vectors
of length > 1 are now  assumed to correspond to multiple files. Because of this
we now use a more explicit way to represent literal data, by using the `I()`
function around the input.

readr 2.0.0 by default uses lazy reading. When you first call a reading
function the delimiters in the file are located, but the data is not actually
read until it is used in your program. This can provide substantial speed
improvements for reading character data. Particularly for interactive
exploration of only a subset of a full dataset.

However this also means that problematic values are not necessarily seen
immediately, a warning will be issued the first time a problem is encountered,
which may happen after initial reading.

Use `lazy = FALSE` if you want to uncover all problems up front or want to use
eager reading for any other reason.

We plan to submit readr 2.0.0 in 2-4 weeks, so you will need to submit these changes to CRAN before then to avoid breaking tests on CRAN.