### PR TITLE
Adding a Warning for Taxonomic Mismatches during Rollup

### DIFF
--- a/R/auk-rollup.r
+++ b/R/auk-rollup.r
@@ -128,8 +128,31 @@ auk_rollup <- function(x, taxonomy_version, drop_higher = TRUE) {
   tax <- dplyr::filter(tax, .data$category %in% include)
   tax <- rbind(tax, undesc)
   tax <- dplyr::select(tax, "scientific_name", "taxon_order")
+  # store species before filtering
+  species_prefilter <- unique(x$scientific_name)
   x <- dplyr::inner_join(x, tax, by = "scientific_name")
+
+  # identify which species were removed
+  species_after <- unique(x$scientific_name)
+  removed_species <- setdiff(species_prefilter, species_after)
+
+  # if species were removed, print a warning
+  if (length(removed_species) > 0) {
+    warning_message <- paste(
+      "Warning message:",
+      "\nRemoved the following species due to invalid taxonomy:\n",
+      paste(removed_species, collapse = ", "),
+      "\n\nIf taxonomy was recently updated, try updating the package:",
+      "\n- Run this command in R: install.packages('auk')",
+      "\n or install the latest version from GitHub: remotes::install_github('CornellLabofOrnithology/auk')"
+    )
+
+    warning(warning_message, call. = FALSE)
+  } 
   
+  # continue with rollup
+  # If all species were removed, return an empty table
+
   if (nrow(x) == 0) {
     if ("subspecies_common_name" %in% names(x)) {
       x$subspecies_common_name <- NULL

--- a/tests/testthat/test_auk-rollup.r
+++ b/tests/testthat/test_auk-rollup.r
@@ -59,7 +59,7 @@ test_that("auk_rollup warns when species are removed", {
   # Expect a warning when running auk_rollup
   expect_warning(
     df_result <- auk_rollup(df_test),
-    regexp = "Removed the following species due to taxonomic errors"
+    regexp = "Removed the following species due to invalid taxonomy"
   )
 
   # Ensure the unknown species was removed

--- a/tests/testthat/test_auk-rollup.r
+++ b/tests/testthat/test_auk-rollup.r
@@ -47,3 +47,25 @@ test_that("auk_rollup keeps higher taxa", {
   expect_true(all(dropped_cols %in% names(ebd)))
   expect_true(all(!dropped_cols %in% names(ebd_ru)))
 })
+
+test_that("auk_rollup warns when species are removed", {
+  df_test <- data.frame(
+    checklist_id = c("chk1", "chk2"),
+    scientific_name = c("Spinus psaltria", "Jiggetus bubingai"),
+    category = c("species", "species"),
+    observation_count = c(10, 5)
+  )
+  
+  # Expect a warning when running auk_rollup
+  expect_warning(
+    df_result <- auk_rollup(df_test),
+    regexp = "Removed the following species due to taxonomic errors"
+  )
+
+  # Ensure the unknown species was removed
+  expect_false("Jiggetus bubingai" %in% df_result$scientific_name)
+
+  # Ensure Lesser Goldfinch remains in the dataset
+  expect_true("Spinus psaltria" %in% df_result$scientific_name)
+})
+


### PR DESCRIPTION
Added a warning to the user if a species in their eBird download is being removed due to its absence from the eBird taxonomy during the taxonomic rollup function. This issue typically occurs when the taxonomy is up to date in the data download, but the user has not updated their installed version of auk accordingly. When this happens, all data for that species is skipped/ignored. A test has also been added for this.