### PR TITLE
Update package version in CITATION

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -15,6 +15,6 @@ bibentry(
   textVersion  =
   paste("Matthew Strimas-Mackey, Eliot Miller, and Wesley Hochachka (2023).",
         "auk: eBird Data Extraction and Processing with AWK.",
-        "R package version 0.7.0.",
+        "R package version 0.8.1.",
         "https://cornelllabofornithology.github.io/auk/")
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,7 +9,7 @@ bibentry(
                    as.person("Wesley Hochachka")
                  ),
   year         = "2023",
-  note         = "R package version 0.7.0",
+  note         = "R package version 0.8.1",
   url          = "https://cornelllabofornithology.github.io/auk/",
 
   textVersion  =


### PR DESCRIPTION
Not sure if this is something you do regularly or periodically, but the package version in the citation is no longer up-to-date with the active package.