### PR TITLE
Httr2 ebird taxonomy v2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     assertthat,
     countrycode (>= 1.0.0),
     dplyr (>= 0.7.8),
-    httr,
+    httr2,
     magrittr,
     readr (>= 2.0.0),
     rlang (>= 0.3.0),

--- a/R/get-ebird-taxonomy.R
+++ b/R/get-ebird-taxonomy.R
@@ -30,7 +30,7 @@
 #' }
 get_ebird_taxonomy <- function(version, locale) {
   # prepare query
-  url <- "https://ebird.org/ws2.0/ref/taxonomy/ebird"
+  url <- "https://api.ebird.org/v2/ref/taxonomy/ebird"
   q <- list(fmt = "csv")
   if (!missing(version)) {
     stopifnot(is_integer(version), version >= 2015)

--- a/R/get-ebird-taxonomy.R
+++ b/R/get-ebird-taxonomy.R
@@ -41,15 +41,21 @@ get_ebird_taxonomy <- function(version, locale) {
     q <- c(q, locale = locale)
   }
   # query
-  response <- tryCatch(httr::GET(url, query = q),
-                       error = function(e) NULL)
-  if (is.null(response)) {
-    stop("eBird taxonomy API cannont be accessed, visit https://ebird.org/ ",
-         "to see if eBird is currently down.")
-  }
-  httr::stop_for_status(response)
+  response <- tryCatch(
+    httr2::request(url) |>
+      httr2::req_url_query(!!!q) |>
+      httr2::req_perform(),
+    error = function(e) {
+      rlang::abort(c(
+        "Cannot access eBird taxonomy API.",
+        "i" = "Check https://ebird.org/ to see if eBird is down.",
+        "x" = conditionMessage(e)
+      ))
+    }
+  )
+  httr2::resp_check_status(response)
   # read to data frame
-  tax <- readBin(response$content, "character")
+  tax <- httr2::resp_body_string(response)
   tax <- suppressWarnings(readr::read_csv(I(tax), col_types = list(), lazy = FALSE))
   names(tax) <- tolower(names(tax))
   # tidy up


### PR DESCRIPTION
This PR migrates taxonomy retrieval to use modern request tooling (`httr2`) and updates the eBird taxonomy endpoint to `api.ebird.org/v2`.

### Changes made
- Updated `get_ebird_taxonomy()` to use:
  - `https://api.ebird.org/v2/ref/taxonomy/ebird`
  - `httr2::request()` + `httr2::req_url_query()` + `httr2::req_perform()`
  - `httr2::resp_check_status()` and `httr2::resp_body_string()`
- Kept `fmt = "csv"` and existing output schema/column mapping unchanged.
- Replaced `httr` with `httr2` in `DESCRIPTION` imports.
